### PR TITLE
Add SPY put-sell analysis toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # Putput
-put sell models 
+
+Tools for analyzing cash-secured put (short put) opportunities on $SPY. The
+project downloads historical pricing data, estimates theoretical option
+premiums with a Black–Scholes model, and produces visual artifacts that help you
+identify when premium yields have been most attractive.
+
+## Features
+
+- Automated download of SPY price history and the 13-week Treasury bill rate
+  (used as the risk-free rate) via [Yahoo! Finance](https://finance.yahoo.com).
+- Rolling volatility estimation and Black–Scholes pricing for 30-day, 5% OTM
+  cash-secured puts (configurable).
+- Visualization of the annualized premium yield over time as well as
+  seasonality trends by month and weekday.
+- Export of the top historical premium windows to CSV along with a JSON
+  summary report of the analysis run.
+
+## Getting Started
+
+1. Create a virtual environment and install the dependencies:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Execute the analysis CLI (this will download market data on first run):
+
+   ```bash
+   python -m putput.cli --spy-period 5y --days-to-expiration 30 --strike-distance 0.05
+   ```
+
+   Available options:
+
+   | Flag | Description |
+   | ---- | ----------- |
+   | `--spy-period` | Lookback period passed to Yahoo Finance (e.g. `1y`, `5y`, `max`). |
+   | `--days-to-expiration` | Days until expiration assumed when estimating the premium. |
+   | `--strike-distance` | Fractional distance below spot for the strike (0.05 = 5% OTM). |
+   | `--output-dir` | Folder where plots, tables, and the summary JSON will be saved. |
+
+3. Inspect the generated artifacts in the specified `--output-dir` (defaults to
+   `artifacts/`):
+
+   - `premium_yield_timeseries.png`: Annualized premium yield over time.
+   - `premium_seasonality_heatmap.png`: Average yield by month and weekday.
+   - `top_put_sell_windows.csv`: Top 25 historical opportunities sorted by
+     annualized yield.
+   - `summary.json`: Machine-readable summary containing aggregate metrics and
+     file paths to generated outputs.
+
+## Notes & Caveats
+
+- The premium estimates rely on a simplified Black–Scholes model using
+  historical volatility; real option prices will differ.
+- Yahoo Finance data can occasionally be rate limited or unavailable. Re-run the
+  CLI if you encounter transient download failures.
+- Consider adjusting the strike distance and expiration inputs to match your
+  personal risk tolerance and preferred option selling cadence.
+
+## License
+
+This project is provided without warranty and for educational purposes only.

--- a/putput/__init__.py
+++ b/putput/__init__.py
@@ -1,0 +1,8 @@
+"""Tools for analyzing cash-secured put opportunities on SPY."""
+
+__all__ = [
+    "data",
+    "analysis",
+    "visualization",
+    "cli",
+]

--- a/putput/analysis.py
+++ b/putput/analysis.py
@@ -1,0 +1,77 @@
+"""Analytical helpers for estimating cash-secured put premiums."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+from scipy.stats import norm
+
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+@dataclass
+class PremiumConfig:
+    """Parameters controlling the premium estimation."""
+
+    days_to_expiration: int = 30
+    strike_distance: float = 0.05  # 5% below spot
+
+
+def annualized_volatility(returns: pd.Series, window: int = 21) -> pd.Series:
+    """Compute annualized volatility from daily returns."""
+
+    daily_vol = returns.rolling(window=window).std()
+    return daily_vol * math.sqrt(TRADING_DAYS_PER_YEAR)
+
+
+def black_scholes_put(
+    spot: float,
+    strike: float,
+    time: float,
+    rate: float,
+    volatility: float,
+) -> float:
+    """Black-Scholes price for a European put option."""
+
+    if spot <= 0 or strike <= 0 or time <= 0 or volatility <= 0:
+        return float("nan")
+
+    d1 = (math.log(spot / strike) + (rate + 0.5 * volatility**2) * time) / (
+        volatility * math.sqrt(time)
+    )
+    d2 = d1 - volatility * math.sqrt(time)
+
+    return strike * math.exp(-rate * time) * norm.cdf(-d2) - spot * norm.cdf(-d1)
+
+
+def estimate_put_premiums(
+    df: pd.DataFrame,
+    config: Optional[PremiumConfig] = None,
+) -> pd.DataFrame:
+    """Estimate put premiums and derived yields for each row in ``df``."""
+
+    config = config or PremiumConfig()
+    data = df.copy()
+    data["volatility"] = annualized_volatility(data["return"], window=21)
+
+    time = config.days_to_expiration / TRADING_DAYS_PER_YEAR
+    strikes = data["close"] * (1 - config.strike_distance)
+
+    premiums = []
+    for date, row in data.iterrows():
+        spot = row["close"]
+        strike = strikes.loc[date]
+        rate = row["risk_free_rate"]
+        vol = row["volatility"]
+        premium = black_scholes_put(spot, strike, time, rate, vol) if pd.notna(vol) else float("nan")
+        premiums.append(premium)
+
+    data["estimated_premium"] = premiums
+    data["premium_yield"] = data["estimated_premium"] / strikes
+    data["annualized_premium_yield"] = data["premium_yield"] * (TRADING_DAYS_PER_YEAR / config.days_to_expiration)
+    data["strike"] = strikes
+    data["days_to_expiration"] = config.days_to_expiration
+    return data.dropna(subset=["estimated_premium"])

--- a/putput/cli.py
+++ b/putput/cli.py
@@ -1,0 +1,116 @@
+"""Command-line interface for generating SPY put-sell analytics."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from . import analysis, data, visualization
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--spy-period",
+        default="10y",
+        help="Historical lookback period to request from Yahoo Finance (e.g. '5y', '1y').",
+    )
+    parser.add_argument(
+        "--days-to-expiration",
+        type=int,
+        default=30,
+        help="Days to expiration used for the theoretical option pricing.",
+    )
+    parser.add_argument(
+        "--strike-distance",
+        type=float,
+        default=0.05,
+        help="Fractional distance below the spot price for the strike (0.05 == 5% OTM).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts"),
+        help="Directory where plots and tables will be saved.",
+    )
+    return parser
+
+
+def run(args: argparse.Namespace) -> None:
+    cfg = data.MarketDataConfig(spy_period=args.spy_period)
+    price_history = data.fetch_spy_history(cfg)
+    risk_free = data.fetch_risk_free_rate(cfg)
+    frame = data.prepare_analysis_frame(price_history, risk_free)
+
+    premium_cfg = analysis.PremiumConfig(
+        days_to_expiration=args.days_to_expiration,
+        strike_distance=args.strike_distance,
+    )
+    enriched = analysis.estimate_put_premiums(frame, premium_cfg)
+
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    visualization.plot_premium_yield_timeseries(
+        enriched,
+        output_path=output_dir / "premium_yield_timeseries.png",
+    )
+    visualization.plot_seasonality_heatmap(
+        enriched,
+        output_path=output_dir / "premium_seasonality_heatmap.png",
+    )
+
+    top_opportunities = (
+        enriched.sort_values("annualized_premium_yield", ascending=False)
+        .head(25)
+        .loc[:, [
+            "close",
+            "strike",
+            "estimated_premium",
+            "premium_yield",
+            "annualized_premium_yield",
+            "volatility",
+        ]]
+    )
+    top_path = output_dir / "top_put_sell_windows.csv"
+    top_opportunities.to_csv(top_path, float_format="%.6f")
+
+    def _to_float(value: float) -> float:
+        if isinstance(value, (np.floating, np.integer)):
+            return float(value)
+        return float(value)
+
+    summary = {
+        "observations": len(enriched),
+        "mean_annualized_yield": float(enriched["annualized_premium_yield"].mean()),
+        "median_annualized_yield": float(enriched["annualized_premium_yield"].median()),
+        "figures": {
+            "timeseries": str(output_dir / "premium_yield_timeseries.png"),
+            "seasonality": str(output_dir / "premium_seasonality_heatmap.png"),
+        },
+        "top_table": str(top_path),
+    }
+    if not top_opportunities.empty:
+        summary["top_window"] = {
+            key: _to_float(value)
+            for key, value in top_opportunities.iloc[0].to_dict().items()
+        }
+
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2))
+
+    print("Artifacts written to", output_dir.resolve())
+    print(summary_path.read_text())
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/putput/data.py
+++ b/putput/data.py
@@ -1,0 +1,63 @@
+"""Data acquisition utilities for SPY option analysis."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class MarketDataConfig:
+    """Configuration for downloading market data."""
+
+    spy_period: str = "10y"
+    spy_interval: str = "1d"
+    risk_free_symbol: str = "^IRX"  # 13-week treasury bill yield
+    risk_free_period: str = "10y"
+    risk_free_interval: str = "1d"
+
+
+def fetch_spy_history(config: Optional[MarketDataConfig] = None) -> pd.DataFrame:
+    """Download historical SPY price data using *yfinance*."""
+
+    config = config or MarketDataConfig()
+    spy = yf.Ticker("SPY")
+    history = spy.history(period=config.spy_period, interval=config.spy_interval)
+    if history.empty:
+        raise RuntimeError("Failed to download SPY historical data.")
+    history.index = pd.to_datetime(history.index)
+    return history
+
+
+def fetch_risk_free_rate(config: Optional[MarketDataConfig] = None) -> pd.Series:
+    """Fetch the risk-free rate series from the 13-week T-bill yield."""
+
+    config = config or MarketDataConfig()
+    irx = yf.download(
+        config.risk_free_symbol,
+        period=config.risk_free_period,
+        interval=config.risk_free_interval,
+        progress=False,
+    )
+    if irx.empty:
+        raise RuntimeError("Failed to download risk-free rate data.")
+
+    rate = irx["Adj Close"].rename("risk_free_rate")
+    rate.index = pd.to_datetime(rate.index)
+    # Convert quoted yield (in percent) to decimal risk-free rate.
+    rate = rate / 100.0
+    return rate
+
+
+def prepare_analysis_frame(
+    price_history: pd.DataFrame,
+    risk_free_rate: pd.Series,
+) -> pd.DataFrame:
+    """Combine price and risk-free data into a single analysis-ready frame."""
+
+    df = price_history[["Close"]].rename(columns={"Close": "close"}).copy()
+    df["return"] = np.log(df["close"]).diff()
+    df["risk_free_rate"] = risk_free_rate.reindex(df.index).ffill()
+    return df.dropna(subset=["risk_free_rate"]).dropna()

--- a/putput/visualization.py
+++ b/putput/visualization.py
@@ -1,0 +1,102 @@
+"""Visualization utilities for SPY cash-secured put analysis."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+from matplotlib.ticker import FuncFormatter
+import numpy as np
+import pandas as pd
+
+
+DEFAULT_STYLE = "seaborn-v0_8"
+
+
+def _setup_style(style: str = DEFAULT_STYLE) -> None:
+    plt.style.use(style)
+
+
+def plot_premium_yield_timeseries(
+    df: pd.DataFrame,
+    output_path: Optional[Path] = None,
+    title: str = "Estimated SPY Put Premium Yield",
+) -> plt.Figure:
+    """Plot the estimated premium yield through time."""
+
+    _setup_style()
+    fig, ax = plt.subplots(figsize=(12, 6))
+    df["annualized_premium_yield"].plot(ax=ax, color="#1f77b4", lw=1.5)
+    ax.set_title(title)
+    ax.set_ylabel("Annualized Yield (Black-Scholes Estimate)")
+    ax.set_xlabel("Date")
+    ax.grid(True, alpha=0.3)
+    ax.yaxis.set_major_formatter(FuncFormatter(lambda x, pos: f"{x:.0%}"))
+    ax.xaxis.set_major_locator(mdates.YearLocator(base=1))
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
+    fig.autofmt_xdate()
+
+    if output_path:
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(output_path, bbox_inches="tight")
+    return fig
+
+
+def plot_seasonality_heatmap(
+    df: pd.DataFrame,
+    output_path: Optional[Path] = None,
+    title: str = "Seasonality of SPY Put Premium Yields",
+) -> plt.Figure:
+    """Plot average yield by month and weekday to highlight seasonal patterns."""
+
+    _setup_style()
+    seasonality = (
+        df.assign(
+            month=lambda x: x.index.month,
+            weekday=lambda x: x.index.day_name(),
+        )
+        .groupby(["month", "weekday"])  # type: ignore[arg-type]
+        ["annualized_premium_yield"]
+        .mean()
+        .unstack()
+        .reindex(columns=["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"])
+        .reindex(index=range(1, 13))
+    )
+    month_labels = [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+    ]
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    cax = ax.imshow(seasonality, aspect="auto", cmap="YlGnBu")
+    ax.set_title(title)
+    ax.set_xlabel("Weekday")
+    ax.set_ylabel("Month")
+    ax.set_xticks(range(len(seasonality.columns)))
+    ax.set_xticklabels(seasonality.columns)
+    ax.set_yticks(range(len(seasonality.index)))
+    ax.set_yticklabels([month_labels[m - 1] for m in seasonality.index])
+
+    for (i, j), val in np.ndenumerate(seasonality.values):
+        ax.text(j, i, f"{val:.0%}", ha="center", va="center", color="black")
+
+    fig.colorbar(cax, ax=ax, format=lambda x, _: f"{x:.0%}")
+
+    if output_path:
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(output_path, bbox_inches="tight")
+
+    return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+matplotlib>=3.7
+numpy>=1.24
+pandas>=2.0
+yfinance>=0.2
+scipy>=1.10


### PR DESCRIPTION
## Summary
- add a data acquisition module that downloads SPY prices and 13-week T-bill yields
- implement Black–Scholes-based premium estimation, visualization helpers, and a CLI workflow
- document setup and usage while declaring the project dependencies

## Testing
- `pip install -r requirements.txt` *(fails: proxy prevented downloading matplotlib)*
- `python -m putput.cli --spy-period 1y --days-to-expiration 30 --strike-distance 0.05` *(fails: numpy not installed due to prior issue)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cd0ea8d4832e96be20c4ae4d7b5f